### PR TITLE
feat(PriceOracle): add PRICE_DECIMALS constant and update scaling logic

### DIFF
--- a/contracts/FeeController.sol
+++ b/contracts/FeeController.sol
@@ -5,6 +5,7 @@ import {IFeeController} from "./interfaces/IFeeController.sol";
 import {ITokenGetter} from "./interfaces/ITokenGetter.sol";
 import {IPriceOracle} from "./interfaces/IPriceOracle.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
 /// @title FeeController
 /// @notice Manages fee configurations and calculations for various function selectors and fee types.
@@ -111,7 +112,7 @@ contract FeeController is Ownable, IFeeController {
         uint256 _tokenPrice = oracle.getTokenPrice(_token);
 
         uint256 _feeAmount = _volume * _config.feePercentage / PERCENTAGE_DIVISOR;
-        uint256 _feeInUSD = _feeAmount * _tokenPrice / 10 ** 18;
+        uint256 _feeInUSD = _feeAmount * _tokenPrice / (10 ** oracle.PRICE_DECIMALS());
 
         return _feeInUSD < _minFeeInUSD ? _minFeeInUSD : _feeInUSD;
     }
@@ -130,7 +131,9 @@ contract FeeController is Ownable, IFeeController {
             revert InvalidTokenWithPriceOfZero();
         }
 
-        return feeInUSD * 10 ** 18 / tokenPrice;
+        uint8 decimals = IERC20Metadata(token).decimals();
+
+        return (feeInUSD * (10 ** decimals)) / tokenPrice;
     }
 
     /// @inheritdoc IFeeController

--- a/contracts/PriceOracle.sol
+++ b/contracts/PriceOracle.sol
@@ -7,6 +7,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IPriceOracle} from "./interfaces/IPriceOracle.sol";
 
 contract PriceOracle is Ownable, IPriceOracle {
+    uint8 public constant PRICE_DECIMALS = 18;
     // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
     // ┃       StateVariable       ┃
     // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
@@ -52,11 +53,11 @@ contract PriceOracle is Ownable, IPriceOracle {
 
         uint256 _absExpo = uint32(-_expo);
 
-        if (_expo <= -18) {
-            return uint256(_price) * (10 ** (_absExpo - 18));
+        if (_expo <= -int32(uint32(PRICE_DECIMALS))) {
+            return uint256(_price) * (10 ** (_absExpo - PRICE_DECIMALS));
         }
 
-        return uint256(_price) * 10 ** (18 - _absExpo);
+        return uint256(_price) * 10 ** (PRICE_DECIMALS - _absExpo);
     }
 
     // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━┓

--- a/contracts/interfaces/IPriceOracle.sol
+++ b/contracts/interfaces/IPriceOracle.sol
@@ -45,4 +45,9 @@ interface IPriceOracle {
     /// @param _token Address of the token.
     /// @return The latest price of the token.
     function getTokenPrice(address _token) external view returns (uint256);
+
+    /// @notice Returns the number of decimals used for the scaled price.
+    /// @dev This value is fixed to match the output of `_scalePythPrice`, which normalizes prices to 18 decimals.
+    /// @return The number of decimals (always 18).
+    function PRICE_DECIMALS() external view returns (uint8);
 }


### PR DESCRIPTION
Use PRICE_DECIMALS constant instead of hardcoded 18 for price scaling Update FeeController to handle token decimals when converting fees Add corresponding test cases for token amount calculation