### PR TITLE
fix: delete automationsToIndex when removing automation

### DIFF
--- a/contracts/StrategyBuilderPlugin.sol
+++ b/contracts/StrategyBuilderPlugin.sol
@@ -336,6 +336,7 @@ contract StrategyBuilderPlugin is BasePlugin, ReentrancyGuard, IStrategyBuilderP
         );
 
         delete automations[automationSID];
+        delete automationsToIndex[automationSID];
 
         emit AutomationDeleted(wallet, id);
     }


### PR DESCRIPTION
Ensure automationsToIndex mapping is cleared alongside automations mapping when deleting an automation to maintain data consistency