### PR TITLE
refactor: use automationSID variable instead of repeated function call

### DIFF
--- a/contracts/StrategyBuilderPlugin.sol
+++ b/contracts/StrategyBuilderPlugin.sol
@@ -184,7 +184,7 @@ contract StrategyBuilderPlugin is BasePlugin, ReentrancyGuard, IStrategyBuilderP
         _changeAutomationInCondition(msg.sender, condition.conditionAddress, condition.id, id, true);
 
         bytes32 automationSID = getStorageId(msg.sender, id);
-        Automation storage _newAutomation = automations[getStorageId(msg.sender, id)];
+        Automation storage _newAutomation = automations[automationSID];
 
         _newAutomation.condition = condition;
         _newAutomation.strategyId = strategyId;


### PR DESCRIPTION
Improve code readability by storing the result of getStorageId in a variable and reusing it, avoiding redundant function calls