### PR TITLE
feat(strategy): add ActionRegistry for validating internal actions

### DIFF
--- a/contracts/ActionRegistry.sol
+++ b/contracts/ActionRegistry.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier:MIT
+pragma solidity ^0.8.26;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IActionRegistry} from "contracts/interfaces/IActionRegistry.sol";
+
+contract ActionRegistry is Ownable, IActionRegistry {
+    // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    // ┃       StateVariable       ┃
+    // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+    mapping(address => bool) private isAllowedAction;
+
+    // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    // ┃     Public Functions      ┃
+    // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+    /// @inheritdoc IActionRegistry
+    function allowAction(address action) external onlyOwner {
+        if (action == address(0)) {
+            revert ZeroAddressNotValid();
+        }
+
+        isAllowedAction[action] = true;
+        emit ActionAllowed(action);
+    }
+
+    /// @inheritdoc IActionRegistry
+    function revokeAction(address action) external onlyOwner {
+        if (!isAllowedAction[action]) {
+            revert ActionNotRegistered();
+        }
+
+        isAllowedAction[action] = false;
+        emit ActionRevoked(action);
+    }
+
+    // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    // ┃       View Functions     ┃
+    // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+    /// @inheritdoc IActionRegistry
+    function isAllowed(address action) external view returns (bool) {
+        return isAllowedAction[action];
+    }
+}

--- a/contracts/interfaces/IActionRegistry.sol
+++ b/contracts/interfaces/IActionRegistry.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+/// @title IActionRegistry
+/// @notice Interface for managing and validating allowed action contract addresses.
+/// @dev Used to whitelist and check access for external action contracts.
+interface IActionRegistry {
+    // ┏━━━━━━━━━━━━━━━━━┓
+    // ┃    Errors       ┃
+    // ┗━━━━━━━━━━━━━━━━━┛
+
+    error ZeroAddressNotValid();
+    error ActionNotRegistered();
+
+    // ┏━━━━━━━━━━━━━━━━━━┓
+    // ┃     Events       ┃
+    // ┗━━━━━━━━━━━━━━━━━━┛
+
+    event ActionAllowed(address indexed action);
+    event ActionRevoked(address indexed action);
+
+    // ┏━━━━━━━━━━━━━━━━━━┓
+    // ┃   Functions      ┃
+    // ┗━━━━━━━━━━━━━━━━━━┛
+
+    /// @notice Allows (whitelists) an action contract address.
+    /// @dev Only callable by the owner or authorized entity.
+    /// @param action The address of the action contract to allow.
+    function allowAction(address action) external;
+
+    /// @notice Revokes a previously allowed action contract address.
+    /// @dev Only callable by the owner or authorized entity.
+    /// @param action The address of the action contract to revoke.
+    function revokeAction(address action) external;
+
+    /// @notice Checks whether a given action contract address is allowed.
+    /// @param action The address to check.
+    /// @return allowed A boolean indicating whether the action is allowed.
+    function isAllowed(address action) external view returns (bool);
+}

--- a/ignition/modules/StrategyBuilderCoreModule.ts
+++ b/ignition/modules/StrategyBuilderCoreModule.ts
@@ -42,13 +42,22 @@ const StrategBuilderCoreModule = buildModule(
       true,
     ]);
 
+    const actionRegistry = m.contract("ActionRegistry");
+
     // Strategy Builder Plugin
     const strategyBuilderPlugin = m.contract("StrategyBuilderPlugin", [
       feeController,
       feeHandler,
+      actionRegistry,
     ]);
 
-    return { priceOracle, feeController, feeHandler, strategyBuilderPlugin };
+    return {
+      priceOracle,
+      feeController,
+      feeHandler,
+      actionRegistry,
+      strategyBuilderPlugin,
+    };
   }
 );
 

--- a/test/ActionRegistry.t.sol
+++ b/test/ActionRegistry.t.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Test, console} from "forge-std/Test.sol";
+import {ActionRegistry} from "contracts/ActionRegistry.sol";
+import {IActionRegistry} from "contracts/interfaces/IActionRegistry.sol";
+
+contract ActionRegistryTest is Test {
+    ActionRegistry registry;
+    address owner = makeAddr("owner");
+    address nonOwner = makeAddr("no-owner");
+    address action1 = makeAddr("action1");
+    address action2 = makeAddr("action2");
+
+    function setUp() public {
+        vm.prank(owner);
+        registry = new ActionRegistry();
+    }
+
+    function test_allowAction_Success() public {
+        vm.prank(owner);
+        registry.allowAction(action1);
+        bool allowed = registry.isAllowed(action1);
+        assertTrue(allowed, "Action should be allowed");
+    }
+
+    function test_allowAction_RevertAllowZeroAddress() public {
+        vm.prank(owner);
+        vm.expectRevert(IActionRegistry.ZeroAddressNotValid.selector);
+        registry.allowAction(address(0));
+    }
+
+    function test_revokeAction_Success() public {
+        vm.startPrank(owner);
+        registry.allowAction(action1);
+        registry.revokeAction(action1);
+        vm.stopPrank();
+
+        bool allowed = registry.isAllowed(action1);
+        assertFalse(allowed, "Action should have been revoked");
+    }
+
+    function test_revokeAction_RevertRevokeUnregistered() public {
+        vm.prank(owner);
+        vm.expectRevert(IActionRegistry.ActionNotRegistered.selector);
+        registry.revokeAction(action2);
+    }
+
+    function test_allowAction_OnlyOwnerCanAllow() public {
+        vm.expectRevert("Ownable: caller is not the owner");
+        vm.prank(nonOwner);
+        registry.allowAction(action1);
+    }
+
+    function test_revokeAction_OnlyOwnerCanRevoke() public {
+        vm.startPrank(owner);
+        registry.allowAction(action1);
+        vm.stopPrank();
+
+        vm.prank(nonOwner);
+        vm.expectRevert("Ownable: caller is not the owner");
+        registry.revokeAction(action1);
+    }
+}


### PR DESCRIPTION
Add ActionRegistry contract to whitelist and validate allowed action contracts Integrate ActionRegistry into StrategyBuilderPlugin to check action validity Include tests for ActionRegistry functionality and plugin integration