### PR TITLE
refactor(FeeController): improve fee calculation with token decimals …

### DIFF
--- a/contracts/PriceOracle.sol
+++ b/contracts/PriceOracle.sol
@@ -9,7 +9,7 @@ import {IPriceOracle} from "./interfaces/IPriceOracle.sol";
 contract PriceOracle is Ownable, IPriceOracle {
     uint8 public constant PRICE_DECIMALS = 18;
 
-    uint8 public constant MAX_ORACLE_DELAY = 120;
+    uint8 public constant MAX_ORACLE_DELAY = 60;
 
     // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
     // ┃       StateVariable       ┃


### PR DESCRIPTION
…handling

Add internal helper function _getTokenDecimals to safely fetch token decimals with fallback Normalize fee amounts to 18 decimals before USD conversion Add zero price check to prevent division by zero
Reduce MAX_ORACLE_DELAY from 120 to 60 seconds